### PR TITLE
overflowing_literals false positive

### DIFF
--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -434,7 +434,7 @@ impl Cpu {
 
                     if dir { // left
                         new_val = old_val.wrapping_shl(1) as u8;
-                        if (old_val & 0b1000_0000) != 0 { self.set_flag(Flag::C) } else { self.reset_flag(Flag::C) };
+                        if (old_val & 0b1000_0000_u8 as i8) != 0 { self.set_flag(Flag::C) } else { self.reset_flag(Flag::C) };
                     } else { // right
                         new_val = old_val.wrapping_shr(1) as u8;
                         if (old_val & 0b0000_0001) != 0 { self.set_flag(Flag::C) } else { self.reset_flag(Flag::C) };


### PR DESCRIPTION
In a future version of Rust the `overflowing_literals` lint will become deny by default. See rust-lang/rust#55632. When checking for breakage in crates uploaded to crates.io it was discovered that this crate will no longer compile thanks to this lint. The error produced is [here](https://crater-reports.s3.amazonaws.com/pr-55632/try%23dc13be39fae8d4c607889b27de374b52586485a3/gh/javierbg.DaMaGed/log.txt). This PR should fix the false positive.